### PR TITLE
UX: reset overridden sidebar "more" button styles

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -123,3 +123,19 @@ $category-badge-style: null !default; // helps detect the category badge styles 
     margin-bottom: 0.5em;
   }
 }
+
+// need to reset some styles overridden by the button mixin
+
+.sidebar-more-section-trigger {
+  justify-content: start;
+  padding-left: var(--d-sidebar-row-horizontal-padding);
+  .d-icon {
+    color: var(--d-sidebar-link-icon-color);
+  }
+  .discourse-no-touch & {
+    &:hover {
+      background: var(--d-sidebar-highlight-background);
+      color: var(--d-sidebar-link-color);
+    }
+  }
+}


### PR DESCRIPTION
Need to look into a core fix to avoid this, but this fixes the issue for now

Before
![image](https://github.com/user-attachments/assets/e63921a7-a874-41e3-bdf3-2c76e5f39534)


After
![image](https://github.com/user-attachments/assets/9eeb18eb-1a02-4b7d-9388-8ddc350b19dc)
