### PR TITLE
UX: update css to override core change

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -9,7 +9,7 @@ $category-badge-style: null !default; // helps detect the category badge styles 
 }
 
 @if $use-category-color-in-composer == "true" {
-  #reply-control {
+  #reply-control.open {
     .grippie {
       transition: background-color 0.25s;
       background-color: var(--composer-category-color, var(--tertiary));


### PR DESCRIPTION
The style was no longer applied since this core change:
https://github.com/discourse/discourse/pull/31936

By adding the `.open` class our style change can take effect, and in turn fixes the system test failure.